### PR TITLE
chore: add OIDC permissions for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   release:
-    name: '/'
+    name: 'Release'
     uses: technology-studio/github-workflows/.github/workflows/_release.yml@main
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  release:
+    name: '/'
+    uses: technology-studio/github-workflows/.github/workflows/_release.yml@main
+    secrets: inherit


### PR DESCRIPTION
Add `id-token: write` and `contents: write` permissions to the release workflow for npm OIDC trusted publishing.